### PR TITLE
Free course release: guided setup + tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,46 @@
-# Required
+# ============================================================
+# Claude Telegram Relay — Environment Variables
+# ============================================================
+# Copy to .env:  cp .env.example .env
+# Then fill in your values below.
+# ============================================================
+
+# --- REQUIRED: Telegram ---
+
+# Bot token from @BotFather
 TELEGRAM_BOT_TOKEN=your_bot_token_from_botfather
+
+# Your Telegram user ID (from @userinfobot)
 TELEGRAM_USER_ID=your_telegram_user_id
 
-# Optional - Paths
-# CLAUDE_PATH=claude                    # Path to claude CLI if not in PATH
-# RELAY_DIR=~/.claude-relay             # Working directory
-# PROJECT_DIR=/path/to/your/project    # Directory where Claude runs (e.g. another repo)
+# --- REQUIRED: Supabase (persistent memory) ---
 
-# Optional - Voice (if you want voice message support)
-# GEMINI_API_KEY=                       # For voice transcription
-# ELEVENLABS_API_KEY=                   # For voice responses
-# ELEVENLABS_VOICE_ID=                  # Your preferred voice
+# Project URL (looks like https://abc123.supabase.co)
+SUPABASE_URL=your_project_url
 
-# Optional - Memory persistence (if using Supabase)
-# SUPABASE_URL=
-# SUPABASE_ANON_KEY=
+# anon public key (starts with eyJ...)
+SUPABASE_ANON_KEY=your_anon_key
+
+# --- RECOMMENDED: Personalization ---
+
+# Your first name
+USER_NAME=Your Name
+
+# Your timezone (IANA format: America/New_York, Europe/Berlin, etc.)
+USER_TIMEZONE=UTC
+
+# --- OPTIONAL: Paths ---
+
+# Claude CLI path (auto-detected if in PATH)
+# CLAUDE_PATH=claude
+
+# Working directory for Claude (defaults to relay's own directory)
+# PROJECT_DIR=/path/to/your/project
+
+# Relay data directory (defaults to ~/.claude-relay)
+# RELAY_DIR=~/.claude-relay
+
+# --- OPTIONAL: Voice Transcription ---
+
+# Google Gemini API key (free tier: ai.google.dev)
+# GEMINI_API_KEY=your_gemini_key

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ node_modules/
 # Bun
 bun.lockb
 
+# Personal config (keep examples, ignore actual)
+config/profile.md
+config/schedule.json
+
 # Runtime files
 *.lock
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bun.lockb
 # Runtime files
 *.lock
 *.log
+logs/
 temp/
 uploads/
 session.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,206 @@
+# Claude Telegram Relay — Setup Guide
+
+> Claude Code reads this file automatically. Walk the user through setup one phase at a time.
+> Ask for what you need, configure everything yourself, and confirm each step works before moving on.
+
+## How This Works
+
+This project turns Telegram into a personal AI assistant powered by Claude.
+
+The user cloned this repo (or gave you the link). Your job: guide them through setup conversationally. Ask questions, save their answers to `.env`, test each step, move on.
+
+Do not dump all phases at once. Start with Phase 1. When it works, move to Phase 2. Let the user control the pace.
+
+If this is a fresh clone, run `bun run setup` first to install dependencies and create `.env`.
+
+---
+
+## Phase 1: Telegram Bot (~3 min)
+
+**You need from the user:**
+- A Telegram bot token from @BotFather
+- Their personal Telegram user ID
+
+**What to tell them:**
+1. Open Telegram, search for @BotFather, send `/newbot`
+2. Pick a display name and a username ending in "bot"
+3. Copy the token BotFather gives them
+4. Get their user ID by messaging @userinfobot on Telegram
+
+**What you do:**
+1. Run `bun run setup` if `.env` does not exist yet
+2. Save `TELEGRAM_BOT_TOKEN` and `TELEGRAM_USER_ID` in `.env`
+3. Run `bun run test:telegram` to verify — it sends a test message to the user
+
+**Done when:** Test message arrives on Telegram.
+
+---
+
+## Phase 2: Database — Supabase (~8 min)
+
+**You need from the user:**
+- Supabase Project URL
+- Supabase anon public key
+
+**What to tell them:**
+1. Go to supabase.com, create a free account
+2. Create a new project (any name, any region close to them)
+3. Wait ~2 minutes for it to provision
+4. Go to Project Settings > API
+5. Copy: Project URL and anon public key
+
+**What you do:**
+1. Save `SUPABASE_URL` and `SUPABASE_ANON_KEY` to `.env`
+2. Tell the user to open the SQL Editor in their Supabase dashboard
+3. Show them the contents of `db/schema.sql` and tell them to paste and run it
+4. Run `bun run test:supabase` to verify tables exist
+
+**Optional — Supabase MCP:**
+If the user wants Claude Code to manage the database directly, guide them:
+```
+claude mcp add supabase -- npx -y @supabase/mcp-server-supabase@latest --access-token ACCESS_TOKEN
+```
+They get their access token at supabase.com/dashboard/account/tokens.
+
+**Done when:** `bun run test:supabase` passes.
+
+---
+
+## Phase 3: Personalize (~3 min)
+
+**Ask the user:**
+- Their first name
+- Their timezone (e.g., America/New_York, Europe/Berlin)
+- What they do for work (one sentence)
+- Any time constraints (e.g., "I pick up my kid at 3pm on weekdays")
+- How they like to be communicated with (brief/detailed, casual/formal)
+
+**What you do:**
+1. Save `USER_NAME` and `USER_TIMEZONE` to `.env`
+2. Copy `config/profile.example.md` to `config/profile.md`
+3. Fill in `config/profile.md` with their answers — the bot loads this on every message
+
+**Done when:** `config/profile.md` exists with their details.
+
+---
+
+## Phase 4: Test (~2 min)
+
+**What you do:**
+1. Run `bun run start`
+2. Tell the user to open Telegram and send a test message to their bot
+3. Wait for confirmation it responded
+4. Press Ctrl+C to stop
+
+**Troubleshooting if it fails:**
+- Wrong bot token → re-check with BotFather
+- Wrong user ID → re-check with @userinfobot
+- Claude CLI not found → `npm install -g @anthropic-ai/claude-code`
+- Bun not installed → `curl -fsSL https://bun.sh/install | bash`
+
+**Done when:** User confirms their bot responded on Telegram.
+
+---
+
+## Phase 5: Always On (~5 min)
+
+Make the bot run in the background, start on boot, restart on crash.
+
+**macOS:**
+```
+bun run setup:launchd -- --service relay
+```
+This auto-generates a plist with correct paths and loads it into launchd.
+
+**Linux/Windows:**
+```
+bun run setup:services -- --service relay
+```
+Uses PM2 for process management.
+
+**Verify:** `launchctl list | grep com.claude` (macOS) or `npx pm2 status` (Linux/Windows)
+
+**Done when:** Bot runs in the background and survives a terminal close.
+
+---
+
+## Phase 6: Proactive AI (Optional, ~5 min)
+
+Two features that turn a chatbot into an assistant.
+
+### Smart Check-ins
+`examples/smart-checkin.ts` — runs on a schedule, gathers context, asks Claude if it should reach out. If yes, sends a brief message. If no, stays silent.
+
+### Morning Briefing
+`examples/morning-briefing.ts` — sends a daily summary. Pattern file with placeholder data fetchers.
+
+**macOS — schedule both:**
+```
+bun run setup:launchd -- --service all
+```
+
+**Linux/Windows — schedule both:**
+```
+bun run setup:services -- --service all
+```
+
+**Done when:** User has scheduled services running, or explicitly skips this phase.
+
+---
+
+## Phase 7: Voice Transcription (Optional, ~3 min)
+
+Lets the bot understand voice messages via Google Gemini.
+
+**You need from the user:**
+- Google Gemini API key (free tier: 15 req/min, 1M tokens/mo)
+
+**What to tell them:**
+1. Go to ai.google.dev
+2. Click "Get API key" or go to aistudio.google.com/app/apikey
+3. Create a key, copy it
+
+**What you do:**
+1. Save `GEMINI_API_KEY` to `.env`
+2. The voice handler in `src/relay.ts` currently returns a placeholder. Wire in Gemini transcription: download the audio, send to Gemini, pass the transcription to Claude.
+
+**Done when:** Key is saved, and voice handler is wired up.
+
+---
+
+## After Setup
+
+Run the full health check:
+```
+bun run setup:verify
+```
+
+Summarize what was set up and what is running. Remind the user:
+- Test by sending a message on Telegram
+- Their bot runs in the background (if Phase 5 was done)
+- Come back to this project folder and type `claude` anytime to make changes
+
+---
+
+## What Comes Next — The Full Version
+
+This free relay covers the essentials. The full version unlocks:
+
+- **6 Specialized AI Agents** — Research, Content, Finance, Strategy, Critic + General orchestrator. Route messages through Telegram forum topics. Run board meetings where all six weigh in.
+- **VPS Deployment** — Your bot on a cloud server that never sleeps. Hybrid mode: free local processing when awake, paid API only when sleeping. $2-5/month.
+- **Real Integrations** — Gmail, Google Calendar, Notion tasks connected via MCP. Smart check-ins pull real data, not patterns.
+- **Human-in-the-Loop** — Claude takes actions (send email, update calendar) but asks first via inline Telegram buttons.
+- **Voice & Phone Calls** — Bot speaks back via ElevenLabs. Calls you when something is urgent.
+- **Fallback AI Models** — Auto-switch to OpenRouter or Ollama when Claude is down. Three layers of intelligence.
+- **Production Infrastructure** — Auto-deploy from GitHub, watchdog monitoring, uninstall scripts, full health checks.
+
+**Get the full course with video walkthroughs:**
+- YouTube: youtube.com/@GodaGo (subscribe for tutorials)
+- Community: skool.com/ai-productivity-hub (full course, direct support, help personalizing for your business)
+
+We also help you personalize the full version for your specific business and workflow. Or package it as a product you sell to your own clients.
+
+The free version gives you a real, working AI assistant.
+The full version gives you a personal AI infrastructure.
+
+Build yours at the AI Productivity Hub.

--- a/README.md
+++ b/README.md
@@ -1,317 +1,165 @@
-# Claude Code Telegram Relay
+# Claude Telegram Relay
 
-**A pattern for running Claude Code as an always-on Telegram bot.**
+A personal AI assistant on Telegram powered by Claude Code.
 
-> **This is a reference implementation, not a copy-paste solution.** Take the patterns here and build your own system tailored to your needs.
+You message it. Claude responds. Text, photos, documents, voice. It remembers across sessions, checks in proactively, and runs in the background.
 
-## What This Is
-
-A minimal relay that connects Telegram to Claude Code CLI. You send a message on Telegram, the relay spawns `claude -p`, and sends the response back. That's it.
+**Created by [Goda Go](https://youtube.com/@GodaGo)** | [AI Productivity Hub Community](https://skool.com/ai-productivity-hub)
 
 ```
-┌──────────────┐     ┌──────────────┐     ┌──────────────┐
-│   Telegram   │────▶│    Relay     │────▶│  Claude CLI  │
-│    (you)     │◀────│  (always on) │◀────│   (spawned)  │
-└──────────────┘     └──────────────┘     └──────────────┘
+You ──▶ Telegram ──▶ Relay ──▶ Claude Code CLI ──▶ Response
+                                    │
+                              Supabase (memory)
 ```
 
-## Why This Approach?
+## What You Get
 
-| Approach | Pros | Cons |
-|----------|------|------|
-| **This (CLI spawn)** | Simple, uses full Claude Code capabilities, all tools available | Spawns new process per message |
-| Claude API direct | Lower latency | No tools, no MCP, no context |
-| Claude Agent SDK | Production-ready, streaming | More complex setup |
-
-The CLI spawn approach is the simplest way to get Claude Code's full power (tools, MCP servers, context) accessible via Telegram.
-
-## Requirements
-
-- [Bun](https://bun.sh/) runtime (or Node.js 18+)
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
-- Telegram Bot Token (from [@BotFather](https://t.me/BotFather))
-- Your Telegram User ID (from [@userinfobot](https://t.me/userinfobot))
+- **Relay**: Send messages on Telegram, get Claude responses back
+- **Memory**: Persistent facts, goals, and conversation history via Supabase
+- **Proactive**: Smart check-ins that know when to reach out (and when not to)
+- **Briefings**: Daily morning summary with goals and schedule
+- **Voice**: Transcribe voice messages via Gemini (optional)
+- **Always On**: Runs in the background, starts on boot, restarts on crash
+- **Guided Setup**: Claude Code reads CLAUDE.md and walks you through everything
 
 ## Quick Start
 
+### Prerequisites
+
+- **[Bun](https://bun.sh)** runtime (`curl -fsSL https://bun.sh/install | bash`)
+- **[Claude Code](https://claude.ai/claude-code)** CLI installed and authenticated
+- A **Telegram** account
+
+### Option A: Guided Setup (Recommended)
+
 ```bash
-# Clone (or fork and customize)
-git clone https://github.com/YOUR_USERNAME/claude-telegram-relay
+git clone https://github.com/godagoo/claude-telegram-relay.git
 cd claude-telegram-relay
+claude
+```
 
-# Install dependencies
-bun install
+Claude Code reads `CLAUDE.md` and walks you through setup conversationally:
 
-# Copy and edit environment variables
-cp .env.example .env
-# Edit .env with your tokens
+1. Create a Telegram bot via BotFather
+2. Set up Supabase for persistent memory
+3. Personalize your profile
+4. Test the bot
+5. Configure always-on services
+6. Set up proactive check-ins and briefings
+7. Add voice transcription (optional)
 
+### Option B: Manual Setup
+
+```bash
+git clone https://github.com/godagoo/claude-telegram-relay.git
+cd claude-telegram-relay
+bun run setup          # Install deps, create .env
+# Edit .env with your API keys
+bun run test:telegram  # Verify bot token
+bun run test:supabase  # Verify database
+bun run start          # Start the bot
+```
+
+## Commands
+
+```bash
 # Run
-bun run src/relay.ts
+bun run start              # Start the bot
+bun run dev                # Start with auto-reload
+
+# Setup & Testing
+bun run setup              # Install dependencies, create .env
+bun run test:telegram      # Test Telegram connection
+bun run test:supabase      # Test Supabase connection
+bun run setup:verify       # Full health check
+
+# Always-On Services
+bun run setup:launchd      # Configure launchd (macOS)
+bun run setup:services     # Configure PM2 (Windows/Linux)
+
+# Use --service flag for specific services:
+# bun run setup:launchd -- --service relay
+# bun run setup:launchd -- --service all    (relay + checkin + briefing)
 ```
 
-## Cross-Platform "Always On" Setup
-
-The relay needs to run continuously. Here's how on each platform:
-
-### macOS (LaunchAgent)
-
-LaunchAgent keeps the bot running and restarts it if it crashes.
-
-```bash
-# Copy the template
-cp daemon/launchagent.plist ~/Library/LaunchAgents/com.claude.telegram-relay.plist
-
-# Edit paths in the plist to match your setup
-nano ~/Library/LaunchAgents/com.claude.telegram-relay.plist
-
-# Load it
-launchctl load ~/Library/LaunchAgents/com.claude.telegram-relay.plist
-
-# Check status
-launchctl list | grep claude
-
-# View logs
-tail -f ~/Library/Logs/claude-telegram-relay.log
-```
-
-**To stop:** `launchctl unload ~/Library/LaunchAgents/com.claude.telegram-relay.plist`
-
-### Linux (systemd)
-
-```bash
-# Copy the template
-sudo cp daemon/claude-relay.service /etc/systemd/system/
-
-# Edit paths and user
-sudo nano /etc/systemd/system/claude-relay.service
-
-# Enable and start
-sudo systemctl daemon-reload
-sudo systemctl enable claude-relay
-sudo systemctl start claude-relay
-
-# Check status
-sudo systemctl status claude-relay
-
-# View logs
-journalctl -u claude-relay -f
-```
-
-### Windows (Task Scheduler)
-
-**Option 1: Task Scheduler (built-in)**
-
-1. Open Task Scheduler (`taskschd.msc`)
-2. Create Basic Task
-3. Trigger: "When the computer starts"
-4. Action: Start a program
-   - Program: `C:\Users\YOU\.bun\bin\bun.exe`
-   - Arguments: `run src/relay.ts`
-   - Start in: `C:\path\to\claude-telegram-relay`
-5. In Properties, check "Run whether user is logged on or not"
-6. In Settings, check "Restart if the task fails"
-
-**Option 2: PM2 (recommended)**
-
-PM2 works on all platforms and handles restarts, logs, and monitoring.
-
-```bash
-# Install PM2
-npm install -g pm2
-
-# Start the relay
-pm2 start src/relay.ts --interpreter bun --name claude-relay
-
-# Save the process list
-pm2 save
-
-# Setup startup script (run the command it outputs)
-pm2 startup
-```
-
-**Option 3: NSSM (Windows Service)**
-
-[NSSM](https://nssm.cc/) turns any script into a Windows service.
-
-```bash
-# Download NSSM, then:
-nssm install claude-relay "C:\Users\YOU\.bun\bin\bun.exe" "run src/relay.ts"
-nssm set claude-relay AppDirectory "C:\path\to\claude-telegram-relay"
-nssm start claude-relay
-```
-
-## Architecture
+## Project Structure
 
 ```
+CLAUDE.md                    # Guided setup (Claude Code reads this)
 src/
-  relay.ts          # Core relay (what you customize)
-
+  relay.ts                   # Core relay daemon
 examples/
-  morning-briefing.ts   # Scheduled daily summary
-  smart-checkin.ts      # Proactive check-ins
-  memory.ts             # Persistent memory pattern
-  supabase-schema.sql   # Optional: cloud persistence
-
+  smart-checkin.ts           # Proactive check-ins
+  morning-briefing.ts        # Daily briefing
+  memory.ts                  # Memory persistence patterns
+config/
+  profile.example.md         # Personalization template
+db/
+  schema.sql                 # Supabase database schema
+setup/
+  install.ts                 # Prerequisites checker
+  test-telegram.ts           # Telegram connectivity test
+  test-supabase.ts           # Supabase connectivity test
+  configure-launchd.ts       # macOS service setup
+  configure-services.ts      # Windows/Linux service setup
+  verify.ts                  # Full health check
 daemon/
-  launchagent.plist     # macOS daemon config
-  claude-relay.service  # Linux systemd config
+  launchagent.plist          # macOS daemon template
+  claude-relay.service       # Linux systemd template
+  README-WINDOWS.md          # Windows options
 ```
 
-## The Core Pattern
+## How It Works
 
 The relay does three things:
+1. **Listen** for Telegram messages (via grammY)
+2. **Spawn** Claude Code CLI with context (your profile, memory, time)
+3. **Send** the response back on Telegram
 
-1. **Listen** for Telegram messages
-2. **Spawn** Claude CLI with the message
-3. **Send** the response back
+Claude Code gives you full power: tools, MCP servers, web search, file access. Not just a model — an AI with hands.
 
-```typescript
-// Simplified core pattern
-bot.on("message:text", async (ctx) => {
-  const response = await spawnClaude(ctx.message.text);
-  await ctx.reply(response);
-});
-
-async function spawnClaude(prompt: string): Promise<string> {
-  const proc = spawn(["claude", "-p", prompt, "--output-format", "text"]);
-  const output = await new Response(proc.stdout).text();
-  return output;
-}
-```
-
-That's the entire pattern. Everything else is enhancement.
-
-## Enhancements You Can Add
-
-### Security (Required)
-```typescript
-// Only respond to your user ID
-if (ctx.from?.id.toString() !== process.env.TELEGRAM_USER_ID) {
-  return; // Ignore unauthorized users
-}
-```
-
-### Session Continuity
-```typescript
-// Resume conversations with --resume
-const proc = spawn([
-  "claude", "-p", prompt,
-  "--resume", sessionId,  // Continue previous conversation
-  "--output-format", "text"
-]);
-```
-
-### Voice Messages
-```typescript
-// Transcribe with Whisper/Gemini, send to Claude
-const transcription = await transcribe(voiceFile);
-const response = await spawnClaude(`[Voice message]: ${transcription}`);
-```
-
-### Images
-```typescript
-// Claude Code can see images if you pass the path
-const response = await spawnClaude(`Analyze this image: ${imagePath}`);
-```
-
-### Persistent Memory
-```typescript
-// Add context to every prompt
-const memory = await loadMemory();
-const fullPrompt = `
-Context: ${memory.facts.join(", ")}
-Goals: ${memory.goals.join(", ")}
-
-User: ${prompt}
-`;
-```
-
-### Scheduled Tasks
-```typescript
-// Run briefings via cron/launchd
-// See examples/morning-briefing.ts
-```
-
-## Examples Included
-
-### Morning Briefing (`examples/morning-briefing.ts`)
-
-Sends a daily summary at a scheduled time:
-- Unread emails
-- Calendar for today
-- Active goals
-- Whatever else you want
-
-Schedule it with cron (Linux), launchd (Mac), or Task Scheduler (Windows).
-
-### Smart Check-in (`examples/smart-checkin.ts`)
-
-Proactive assistant that checks in based on context:
-- Time since last message
-- Pending goals with deadlines
-- Calendar events coming up
-
-Claude decides IF and WHAT to say.
-
-### Memory Persistence (`examples/memory.ts`)
-
-Pattern for remembering facts and goals across sessions:
-- Local JSON file (simple)
-- Supabase (cloud, searchable)
-- Any database you prefer
+Your bot remembers between sessions via Supabase: conversation history, facts you share, goals you track. The smart check-in script gathers this context and lets Claude decide whether to reach out.
 
 ## Environment Variables
 
+See `.env.example` for all options. The essentials:
+
 ```bash
 # Required
-TELEGRAM_BOT_TOKEN=       # From @BotFather
-TELEGRAM_USER_ID=         # From @userinfobot (for security)
+TELEGRAM_BOT_TOKEN=     # From @BotFather
+TELEGRAM_USER_ID=       # From @userinfobot
+SUPABASE_URL=           # From Supabase dashboard
+SUPABASE_ANON_KEY=      # From Supabase dashboard
 
-# Optional - Paths (defaults work for most setups)
-CLAUDE_PATH=claude        # Path to claude CLI (if not in PATH)
-RELAY_DIR=~/.claude-relay # Working directory for temp files
+# Recommended
+USER_NAME=              # Your first name
+USER_TIMEZONE=          # e.g., America/New_York
 
-# Optional - Features
-SUPABASE_URL=             # For cloud memory persistence
-SUPABASE_ANON_KEY=        # For cloud memory persistence
-GEMINI_API_KEY=           # For voice transcription
-ELEVENLABS_API_KEY=       # For voice responses
+# Optional
+GEMINI_API_KEY=         # Voice transcription (free tier)
 ```
 
-## FAQ
+## The Full Version
 
-**Q: Why spawn CLI instead of using the API directly?**
+This free relay covers the essentials. The full version in the [AI Productivity Hub](https://skool.com/ai-productivity-hub) community unlocks:
 
-The CLI gives you everything: tools, MCP servers, context management, permissions. The API is just the model. If you want the full Claude Code experience on mobile, you spawn the CLI.
+- **6 Specialized AI Agents** — Research, Content, Finance, Strategy, Critic + General orchestrator via Telegram forum topics
+- **VPS Deployment** — Always-on cloud server with hybrid mode ($2-5/month)
+- **Real Integrations** — Gmail, Calendar, Notion connected via MCP
+- **Human-in-the-Loop** — Claude asks before taking actions via inline buttons
+- **Voice & Phone Calls** — Bot speaks back via ElevenLabs, calls when urgent
+- **Fallback AI Models** — Auto-switch to OpenRouter or Ollama when Claude is down
+- **Production Infrastructure** — Auto-deploy, watchdog, uninstall scripts
 
-**Q: Isn't spawning a process slow?**
+We also help you personalize it for your business, or package it as a product for your clients.
 
-It's ~1-2 seconds overhead. For a personal assistant, that's fine. If you need sub-second responses, use the Agent SDK instead.
-
-**Q: Can I use this with other CLIs?**
-
-Yes. The pattern works with any CLI that accepts prompts and returns text. Swap `claude` for your preferred tool.
-
-**Q: How do I handle long-running tasks?**
-
-Claude Code can take minutes for complex tasks. The relay handles this by streaming or waiting. Set appropriate timeouts.
-
-**Q: What about MCP servers?**
-
-They work. Claude CLI uses your `~/.claude/settings.json` config, so all your MCP servers are available.
-
-## Security Notes
-
-1. **Always verify user ID** - Never run an open bot
-2. **Don't commit `.env`** - It's in `.gitignore`
-3. **Limit permissions** - Consider `--permission-mode` flag
-4. **Review commands** - Claude can execute bash, be aware of what you're allowing
-
-## Credits
-
-Built by [Goda](https://www.youtube.com/@godago) as part of the Personal AI Infrastructure project.
+**Subscribe on YouTube:** [youtube.com/@GodaGo](https://youtube.com/@GodaGo)
+**Join the community:** [skool.com/ai-productivity-hub](https://skool.com/ai-productivity-hub)
 
 ## License
 
-MIT - Take it, customize it, make it yours.
+MIT — Take it, customize it, make it yours.
+
+---
+
+Built by [Goda Go](https://youtube.com/@GodaGo)

--- a/config/profile.example.md
+++ b/config/profile.example.md
@@ -1,0 +1,29 @@
+# Your Profile
+
+> Copy this file to config/profile.md and fill in your details.
+> Your bot loads this on every message to personalize responses.
+
+## About You
+
+- **Name:** Your Name
+- **Timezone:** UTC
+- **Occupation:** What you do for work
+- **Location:** Your city (optional)
+
+## Goals
+
+- Goal 1
+- Goal 2
+- Goal 3
+
+## Constraints
+
+- Any time constraints (e.g., "Pick up kid at 3pm on weekdays")
+- Work hours
+- Other scheduling rules
+
+## Communication Style
+
+- How you prefer responses (brief/detailed, casual/formal)
+- Any pet peeves about AI responses
+- Preferred language

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,156 @@
+-- Optional: Supabase Schema for Cloud Memory
+-- Run this in Supabase SQL Editor if you want cloud persistence
+-- This enables: conversation history, semantic search, goals tracking
+
+-- Enable vector extension for semantic search (optional)
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ============================================================
+-- MESSAGES TABLE (Conversation History)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS messages (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+  content TEXT NOT NULL,
+  channel TEXT DEFAULT 'telegram',
+  metadata JSONB DEFAULT '{}',
+  embedding VECTOR(1536) -- For semantic search (optional)
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_created_at ON messages(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_messages_channel ON messages(channel);
+
+-- ============================================================
+-- MEMORY TABLE (Facts & Goals)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS memory (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  type TEXT NOT NULL CHECK (type IN ('fact', 'goal', 'completed_goal', 'preference')),
+  content TEXT NOT NULL,
+  deadline TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  priority INTEGER DEFAULT 0,
+  metadata JSONB DEFAULT '{}',
+  embedding VECTOR(1536)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memory_type ON memory(type);
+CREATE INDEX IF NOT EXISTS idx_memory_created_at ON memory(created_at DESC);
+
+-- ============================================================
+-- LOGS TABLE (Observability - Optional)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS logs (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  level TEXT DEFAULT 'info' CHECK (level IN ('debug', 'info', 'warn', 'error')),
+  event TEXT NOT NULL,
+  message TEXT,
+  metadata JSONB DEFAULT '{}',
+  session_id TEXT,
+  duration_ms INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_logs_created_at ON logs(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_logs_level ON logs(level);
+
+-- ============================================================
+-- ROW LEVEL SECURITY
+-- ============================================================
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memory ENABLE ROW LEVEL SECURITY;
+ALTER TABLE logs ENABLE ROW LEVEL SECURITY;
+
+-- Allow all for service role (your bot uses service key)
+CREATE POLICY "Allow all for service role" ON messages FOR ALL USING (true);
+CREATE POLICY "Allow all for service role" ON memory FOR ALL USING (true);
+CREATE POLICY "Allow all for service role" ON logs FOR ALL USING (true);
+
+-- ============================================================
+-- HELPER FUNCTIONS
+-- ============================================================
+
+-- Get recent messages for context
+CREATE OR REPLACE FUNCTION get_recent_messages(limit_count INTEGER DEFAULT 20)
+RETURNS TABLE (
+  id UUID,
+  created_at TIMESTAMPTZ,
+  role TEXT,
+  content TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT m.id, m.created_at, m.role, m.content
+  FROM messages m
+  ORDER BY m.created_at DESC
+  LIMIT limit_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Get active goals
+CREATE OR REPLACE FUNCTION get_active_goals()
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  deadline TIMESTAMPTZ,
+  priority INTEGER
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT m.id, m.content, m.deadline, m.priority
+  FROM memory m
+  WHERE m.type = 'goal'
+  ORDER BY m.priority DESC, m.created_at DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Get all facts
+CREATE OR REPLACE FUNCTION get_facts()
+RETURNS TABLE (
+  id UUID,
+  content TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT m.id, m.content
+  FROM memory m
+  WHERE m.type = 'fact'
+  ORDER BY m.created_at DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- SEMANTIC SEARCH (Optional - requires embeddings)
+-- ============================================================
+
+-- Match messages by embedding similarity
+CREATE OR REPLACE FUNCTION match_messages(
+  query_embedding VECTOR(1536),
+  match_threshold FLOAT DEFAULT 0.7,
+  match_count INT DEFAULT 10
+)
+RETURNS TABLE (
+  id UUID,
+  content TEXT,
+  role TEXT,
+  created_at TIMESTAMPTZ,
+  similarity FLOAT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    m.id,
+    m.content,
+    m.role,
+    m.created_at,
+    1 - (m.embedding <=> query_embedding) AS similarity
+  FROM messages m
+  WHERE m.embedding IS NOT NULL
+    AND 1 - (m.embedding <=> query_embedding) > match_threshold
+  ORDER BY m.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:telegram": "bun run setup/test-telegram.ts",
     "test:supabase": "bun run setup/test-supabase.ts",
     "setup:launchd": "bun run setup/configure-launchd.ts",
-    "setup:services": "bun run setup/configure-services.ts"
+    "setup:services": "bun run setup/configure-services.ts",
+    "setup:verify": "bun run setup/verify.ts"
   },
   "dependencies": {
     "grammy": "^1.21.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "start": "bun run src/relay.ts",
-    "dev": "bun run --watch src/relay.ts"
+    "dev": "bun run --watch src/relay.ts",
+    "setup": "bun run setup/install.ts"
   },
   "dependencies": {
     "grammy": "^1.21.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "start": "bun run src/relay.ts",
     "dev": "bun run --watch src/relay.ts",
-    "setup": "bun run setup/install.ts"
+    "setup": "bun run setup/install.ts",
+    "test:telegram": "bun run setup/test-telegram.ts",
+    "test:supabase": "bun run setup/test-supabase.ts"
   },
   "dependencies": {
     "grammy": "^1.21.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "bun run --watch src/relay.ts",
     "setup": "bun run setup/install.ts",
     "test:telegram": "bun run setup/test-telegram.ts",
-    "test:supabase": "bun run setup/test-supabase.ts"
+    "test:supabase": "bun run setup/test-supabase.ts",
+    "setup:launchd": "bun run setup/configure-launchd.ts",
+    "setup:services": "bun run setup/configure-services.ts"
   },
   "dependencies": {
     "grammy": "^1.21.1"

--- a/setup/configure-launchd.ts
+++ b/setup/configure-launchd.ts
@@ -1,0 +1,244 @@
+/**
+ * Claude Telegram Relay — Configure launchd (macOS)
+ *
+ * Generates and loads launchd plist files with correct paths
+ * for the current user and project location.
+ *
+ * Usage: bun run setup/configure-launchd.ts [--service relay|checkin|briefing|all]
+ */
+
+import { writeFile, readFile } from "fs/promises";
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+const HOME = homedir();
+const USERNAME = HOME.split("/").pop() || "user";
+const LAUNCH_AGENTS = join(HOME, "Library", "LaunchAgents");
+const LOGS_DIR = join(PROJECT_ROOT, "logs");
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+
+// Find bun path
+async function findBun(): Promise<string> {
+  const candidates = [
+    join(HOME, ".bun", "bin", "bun"),
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  // Fallback: which bun
+  const proc = Bun.spawn(["which", "bun"], { stdout: "pipe" });
+  const out = await new Response(proc.stdout).text();
+  return out.trim() || "bun";
+}
+
+function generatePlist(opts: {
+  label: string;
+  script: string;
+  keepAlive: boolean;
+  calendarIntervals?: { Hour: number; Minute: number }[];
+}): string {
+  const bunPath = findBunSync;
+
+  let scheduling = "";
+  if (opts.calendarIntervals) {
+    scheduling = `
+    <key>StartCalendarInterval</key>
+    <array>${opts.calendarIntervals
+      .map(
+        (ci) => `
+        <dict>
+            <key>Hour</key>
+            <integer>${ci.Hour}</integer>
+            <key>Minute</key>
+            <integer>${ci.Minute}</integer>
+        </dict>`
+      )
+      .join("")}
+    </array>`;
+  }
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${opts.label}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${bunPath}</string>
+        <string>run</string>
+        <string>${opts.script}</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${PROJECT_ROOT}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${HOME}/.bun/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>${HOME}</string>
+    </dict>
+${opts.keepAlive ? `
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+` : ""}${scheduling}
+    <key>StandardOutPath</key>
+    <string>${LOGS_DIR}/${opts.label}.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOGS_DIR}/${opts.label}.error.log</string>
+</dict>
+</plist>`;
+}
+
+let findBunSync = "";
+
+interface ServiceConfig {
+  label: string;
+  script: string;
+  keepAlive: boolean;
+  calendarIntervals?: { Hour: number; Minute: number }[];
+  description: string;
+}
+
+const SERVICES: Record<string, ServiceConfig> = {
+  relay: {
+    label: "com.claude.telegram-relay",
+    script: "src/relay.ts",
+    keepAlive: true,
+    description: "Main bot (always running, restarts on crash)",
+  },
+  checkin: {
+    label: "com.claude.smart-checkin",
+    script: "examples/smart-checkin.ts",
+    keepAlive: false,
+    calendarIntervals: [
+      { Hour: 9, Minute: 0 },
+      { Hour: 10, Minute: 30 },
+      { Hour: 12, Minute: 0 },
+      { Hour: 14, Minute: 0 },
+      { Hour: 16, Minute: 0 },
+      { Hour: 18, Minute: 0 },
+    ],
+    description: "Smart check-ins (runs during work hours)",
+  },
+  briefing: {
+    label: "com.claude.morning-briefing",
+    script: "examples/morning-briefing.ts",
+    keepAlive: false,
+    calendarIntervals: [{ Hour: 9, Minute: 0 }],
+    description: "Morning briefing (daily at 9am)",
+  },
+};
+
+async function installService(name: string, config: ServiceConfig): Promise<boolean> {
+  const plistPath = join(LAUNCH_AGENTS, `${config.label}.plist`);
+
+  // Generate plist
+  const content = generatePlist(config);
+  await writeFile(plistPath, content);
+  console.log(`  ${PASS} Generated ${config.label}.plist`);
+
+  // Unload if already loaded
+  const unload = Bun.spawn(["launchctl", "unload", plistPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await unload.exited;
+
+  // Load
+  const load = Bun.spawn(["launchctl", "load", plistPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const loadErr = await new Response(load.stderr).text();
+  const loadCode = await load.exited;
+
+  if (loadCode !== 0) {
+    console.log(`  ${FAIL} Failed to load: ${loadErr.trim()}`);
+    return false;
+  }
+
+  console.log(`  ${PASS} Loaded — ${config.description}`);
+  return true;
+}
+
+async function main() {
+  if (process.platform !== "darwin") {
+    console.log(`\n  ${FAIL} This script is for macOS only.`);
+    console.log(`      ${dim("On Linux/Windows, use: bun run setup/configure-services.ts")}`);
+    process.exit(1);
+  }
+
+  findBunSync = await findBun();
+
+  // Parse --service flag
+  const args = process.argv.slice(2);
+  const serviceIdx = args.indexOf("--service");
+  const serviceArg = serviceIdx !== -1 ? args[serviceIdx + 1] : "relay";
+
+  const toInstall = serviceArg === "all" ? Object.keys(SERVICES) : [serviceArg];
+
+  console.log("");
+  console.log(bold("  Configure launchd Services"));
+  console.log(dim(`  Bun: ${findBunSync}`));
+  console.log(dim(`  Project: ${PROJECT_ROOT}`));
+  console.log("");
+
+  // Ensure logs directory exists
+  if (!existsSync(LOGS_DIR)) {
+    const { mkdirSync } = await import("fs");
+    mkdirSync(LOGS_DIR, { recursive: true });
+  }
+
+  let allOk = true;
+  for (const name of toInstall) {
+    const config = SERVICES[name];
+    if (!config) {
+      console.log(`  ${FAIL} Unknown service: ${name}`);
+      console.log(`      ${dim("Available: relay, checkin, briefing, all")}`);
+      allOk = false;
+      continue;
+    }
+    const ok = await installService(name, config);
+    if (!ok) allOk = false;
+  }
+
+  console.log("");
+  if (allOk) {
+    console.log(`  ${green("Done!")} Services are running.`);
+    console.log("");
+    console.log(`  ${dim("Check status:")}  launchctl list | grep com.claude`);
+    console.log(`  ${dim("View logs:")}     tail -f ${LOGS_DIR}/com.claude.telegram-relay.log`);
+    console.log(`  ${dim("Stop all:")}      bun run setup/configure-launchd.ts --unload`);
+  }
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});

--- a/setup/configure-services.ts
+++ b/setup/configure-services.ts
@@ -1,0 +1,147 @@
+/**
+ * Claude Telegram Relay — Configure Services (Windows/Linux)
+ *
+ * Sets up PM2 for process management on non-macOS systems.
+ *
+ * Usage: bun run setup/configure-services.ts [--service relay|checkin|briefing|all]
+ */
+
+import { existsSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+const LOGS_DIR = join(PROJECT_ROOT, "logs");
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+
+async function run(cmd: string[]): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const proc = Bun.spawn(cmd, { cwd: PROJECT_ROOT, stdout: "pipe", stderr: "pipe" });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const code = await proc.exited;
+    return { ok: code === 0, stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch {
+    return { ok: false, stdout: "", stderr: "Command not found" };
+  }
+}
+
+interface ServiceDef {
+  name: string;
+  script: string;
+  cron?: string;
+  description: string;
+}
+
+const SERVICES: Record<string, ServiceDef> = {
+  relay: {
+    name: "claude-telegram-relay",
+    script: "src/relay.ts",
+    description: "Main bot (always running)",
+  },
+  checkin: {
+    name: "claude-smart-checkin",
+    script: "examples/smart-checkin.ts",
+    cron: "*/30 9-18 * * *",
+    description: "Smart check-ins (every 30 min, 9am-6pm)",
+  },
+  briefing: {
+    name: "claude-morning-briefing",
+    script: "examples/morning-briefing.ts",
+    cron: "0 9 * * *",
+    description: "Morning briefing (daily at 9am)",
+  },
+};
+
+async function checkPm2(): Promise<boolean> {
+  const result = await run(["npx", "pm2", "--version"]);
+  if (result.ok) {
+    console.log(`  ${PASS} PM2: v${result.stdout}`);
+    return true;
+  }
+  console.log(`  ${FAIL} PM2 not found`);
+  console.log(`      ${dim("Install: npm install -g pm2")}`);
+  return false;
+}
+
+async function installService(config: ServiceDef): Promise<boolean> {
+  if (config.cron) {
+    // Scheduled service — show cron instructions
+    console.log(`  ${PASS} ${config.name}: add to crontab manually`);
+    console.log(`      ${dim(`${config.cron} cd ${PROJECT_ROOT} && bun run ${config.script}`)}`);
+    return true;
+  }
+
+  // Always-on service — use PM2
+  // Stop existing first
+  await run(["npx", "pm2", "delete", config.name]);
+
+  const result = await run([
+    "npx", "pm2", "start", config.script,
+    "--interpreter", "bun",
+    "--name", config.name,
+    "--cwd", PROJECT_ROOT,
+    "-o", join(LOGS_DIR, `${config.name}.log`),
+    "-e", join(LOGS_DIR, `${config.name}.error.log`),
+  ]);
+
+  if (result.ok) {
+    console.log(`  ${PASS} ${config.name} started — ${config.description}`);
+    return true;
+  }
+  console.log(`  ${FAIL} Failed to start ${config.name}: ${result.stderr}`);
+  return false;
+}
+
+async function main() {
+  if (process.platform === "darwin") {
+    console.log(`\n  You're on macOS. Use launchd instead:`);
+    console.log(`      ${dim("bun run setup/configure-launchd.ts")}`);
+    process.exit(0);
+  }
+
+  // Parse --service flag
+  const args = process.argv.slice(2);
+  const serviceIdx = args.indexOf("--service");
+  const serviceArg = serviceIdx !== -1 ? args[serviceIdx + 1] : "relay";
+  const toInstall = serviceArg === "all" ? Object.keys(SERVICES) : [serviceArg];
+
+  console.log("");
+  console.log(bold("  Configure Services (PM2)"));
+  console.log("");
+
+  const pm2Ok = await checkPm2();
+  if (!pm2Ok) process.exit(1);
+
+  if (!existsSync(LOGS_DIR)) mkdirSync(LOGS_DIR, { recursive: true });
+
+  console.log("");
+  for (const name of toInstall) {
+    const config = SERVICES[name];
+    if (!config) {
+      console.log(`  ${FAIL} Unknown service: ${name}`);
+      continue;
+    }
+    await installService(config);
+  }
+
+  // Save PM2 config for auto-restart on reboot
+  await run(["npx", "pm2", "save"]);
+  console.log("");
+  console.log(`  ${dim("Auto-start on boot:")} npx pm2 startup`);
+  console.log(`  ${dim("Check status:")}        npx pm2 status`);
+  console.log(`  ${dim("View logs:")}           npx pm2 logs`);
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});

--- a/setup/install.ts
+++ b/setup/install.ts
@@ -1,0 +1,174 @@
+/**
+ * Claude Telegram Relay — Setup
+ *
+ * Checks prerequisites, installs dependencies, creates directories,
+ * and prepares .env file.
+ *
+ * Usage: bun run setup/install.ts
+ */
+
+import { existsSync, mkdirSync, copyFileSync } from "fs";
+import { join, dirname } from "path";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+const REQUIRED_DIRS = ["logs", "temp", "uploads"];
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const cyan = (s: string) => `\x1b[36m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+const WARN = yellow("!");
+
+async function run(cmd: string[]): Promise<{ ok: boolean; stdout: string }> {
+  try {
+    const proc = Bun.spawn(cmd, {
+      cwd: PROJECT_ROOT,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const code = await proc.exited;
+    return { ok: code === 0, stdout: stdout.trim() };
+  } catch {
+    return { ok: false, stdout: "" };
+  }
+}
+
+// --- Checks ---
+
+async function checkBun(): Promise<boolean> {
+  const result = await run(["bun", "--version"]);
+  if (result.ok) {
+    console.log(`  ${PASS} Bun: v${result.stdout}`);
+    return true;
+  }
+  console.log(`  ${FAIL} Bun: not installed`);
+  console.log(`      ${dim("Install: curl -fsSL https://bun.sh/install | bash")}`);
+  return false;
+}
+
+async function checkClaude(): Promise<boolean> {
+  const claudePath = process.env.CLAUDE_PATH;
+  if (claudePath) {
+    const result = await run([claudePath, "--version"]);
+    if (result.ok) {
+      console.log(`  ${PASS} Claude Code: ${result.stdout}`);
+      return true;
+    }
+  }
+
+  const findCmd = process.platform === "win32" ? ["where", "claude"] : ["which", "claude"];
+  const which = await run(findCmd);
+  if (which.ok) {
+    const version = await run(["claude", "--version"]);
+    console.log(`  ${PASS} Claude Code: ${version.ok ? version.stdout : "found"}`);
+    return true;
+  }
+
+  console.log(`  ${FAIL} Claude Code: not installed`);
+  console.log(`      ${dim("Install: npm install -g @anthropic-ai/claude-code")}`);
+  return false;
+}
+
+// --- Install ---
+
+async function installDeps(): Promise<boolean> {
+  console.log(`\n  Installing dependencies...`);
+  const result = await run(["bun", "install"]);
+  if (result.ok) {
+    console.log(`  ${PASS} Dependencies installed`);
+    return true;
+  }
+  console.log(`  ${FAIL} bun install failed`);
+  return false;
+}
+
+function createDirs(): void {
+  for (const dir of REQUIRED_DIRS) {
+    const fullPath = join(PROJECT_ROOT, dir);
+    if (!existsSync(fullPath)) {
+      mkdirSync(fullPath, { recursive: true });
+      console.log(`  ${PASS} Created ${dir}/`);
+    } else {
+      console.log(`  ${PASS} ${dir}/ ${dim("(exists)")}`);
+    }
+  }
+}
+
+function setupEnv(): boolean {
+  const envPath = join(PROJECT_ROOT, ".env");
+  const examplePath = join(PROJECT_ROOT, ".env.example");
+
+  if (existsSync(envPath)) {
+    console.log(`  ${PASS} .env ${dim("(exists)")}`);
+    return true;
+  }
+
+  if (!existsSync(examplePath)) {
+    console.log(`  ${FAIL} .env.example not found`);
+    return false;
+  }
+
+  copyFileSync(examplePath, envPath);
+  console.log(`  ${WARN} .env created from .env.example`);
+  console.log(`      ${yellow(">>> Edit .env and add your API keys <<<")}`);
+  return false;
+}
+
+// --- Main ---
+
+async function main() {
+  const platform = { darwin: "macOS", win32: "Windows", linux: "Linux" }[process.platform] || process.platform;
+
+  console.log("");
+  console.log(bold("  Claude Telegram Relay — Setup"));
+  console.log(dim(`  ${platform} • ${process.arch}`));
+
+  // 1. Prerequisites
+  console.log(`\n${cyan("  [1/4] Prerequisites")}`);
+  const bunOk = await checkBun();
+  if (!bunOk) {
+    console.log(`\n  ${red("Bun is required. Install it first.")}`);
+    process.exit(1);
+  }
+  await checkClaude();
+
+  // 2. Dependencies
+  console.log(`\n${cyan("  [2/4] Dependencies")}`);
+  const depsOk = await installDeps();
+  if (!depsOk) process.exit(1);
+
+  // 3. Directories
+  console.log(`\n${cyan("  [3/4] Directories")}`);
+  createDirs();
+
+  // 4. Environment
+  console.log(`\n${cyan("  [4/4] Environment")}`);
+  const envReady = setupEnv();
+
+  // Summary
+  console.log(`\n${bold("  Next steps:")}`);
+  console.log(dim("  ----------"));
+
+  const steps: string[] = [];
+  if (!envReady) {
+    steps.push(`Edit .env with your API keys: ${cyan("$EDITOR .env")}`);
+  }
+  steps.push(`Test Telegram connection: ${cyan("bun run setup/test-telegram.ts")}`);
+  steps.push(`Test Supabase connection: ${cyan("bun run setup/test-supabase.ts")}`);
+  steps.push(`Start the bot: ${cyan("bun run start")}`);
+
+  steps.forEach((step, i) => console.log(`  ${i + 1}. ${step}`));
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});

--- a/setup/test-supabase.ts
+++ b/setup/test-supabase.ts
@@ -1,0 +1,118 @@
+/**
+ * Claude Telegram Relay — Test Supabase Connection
+ *
+ * Verifies Supabase URL and anon key are valid, and checks if
+ * required tables exist.
+ *
+ * Usage: bun run setup/test-supabase.ts
+ */
+
+import { join, dirname } from "path";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+const WARN = yellow("!");
+
+// Load .env manually
+async function loadEnv(): Promise<Record<string, string>> {
+  const envPath = join(PROJECT_ROOT, ".env");
+  try {
+    const content = await Bun.file(envPath).text();
+    const vars: Record<string, string> = {};
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      vars[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+    return vars;
+  } catch {
+    return {};
+  }
+}
+
+const REQUIRED_TABLES = ["messages", "memory", "logs"];
+
+async function main() {
+  console.log("");
+  console.log(bold("  Supabase Connection Test"));
+  console.log("");
+
+  const env = await loadEnv();
+  const url = env.SUPABASE_URL || process.env.SUPABASE_URL || "";
+  const key = env.SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+
+  // Check URL
+  if (!url || url === "your_project_url") {
+    console.log(`  ${FAIL} SUPABASE_URL not set in .env`);
+    console.log(`      ${dim("Get it from Supabase > Project Settings > API")}`);
+    process.exit(1);
+  }
+  console.log(`  ${PASS} Supabase URL: ${url}`);
+
+  // Check key
+  if (!key || key === "your_anon_key") {
+    console.log(`  ${FAIL} SUPABASE_ANON_KEY not set in .env`);
+    console.log(`      ${dim("Get it from Supabase > Project Settings > API")}`);
+    process.exit(1);
+  }
+  console.log(`  ${PASS} Anon key found`);
+
+  // Test connection by querying each required table
+  console.log(`\n  Testing connection...`);
+
+  let allTablesExist = true;
+
+  for (const table of REQUIRED_TABLES) {
+    try {
+      const res = await fetch(`${url}/rest/v1/${table}?select=*&limit=1`, {
+        headers: {
+          apikey: key,
+          Authorization: `Bearer ${key}`,
+        },
+      });
+
+      if (res.status === 200) {
+        console.log(`  ${PASS} Table "${table}" exists`);
+      } else if (res.status === 404 || res.status === 406) {
+        console.log(`  ${FAIL} Table "${table}" not found`);
+        allTablesExist = false;
+      } else {
+        const body = await res.text();
+        console.log(`  ${FAIL} Table "${table}": ${res.status} ${body.slice(0, 100)}`);
+        allTablesExist = false;
+      }
+    } catch (err: any) {
+      console.log(`  ${FAIL} Could not reach Supabase`);
+      console.log(`      ${dim(err.message)}`);
+      process.exit(1);
+    }
+  }
+
+  if (!allTablesExist) {
+    console.log(`\n  ${WARN} Some tables are missing. Run the schema in your Supabase SQL Editor:`);
+    console.log(`      ${dim("1. Open your Supabase dashboard > SQL Editor")}`);
+    console.log(`      ${dim("2. Paste contents of db/schema.sql")}`);
+    console.log(`      ${dim("3. Click Run")}`);
+    console.log(`      ${dim("4. Re-run this test")}`);
+  } else {
+    console.log(`\n  ${green("All good!")} Supabase is configured correctly.`);
+  }
+
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});

--- a/setup/test-telegram.ts
+++ b/setup/test-telegram.ts
@@ -1,0 +1,123 @@
+/**
+ * Claude Telegram Relay — Test Telegram Connection
+ *
+ * Verifies bot token and user ID are valid by sending a test message.
+ *
+ * Usage: bun run setup/test-telegram.ts
+ */
+
+import { join, dirname } from "path";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+
+// Load .env manually (no dotenv dependency)
+async function loadEnv(): Promise<Record<string, string>> {
+  const envPath = join(PROJECT_ROOT, ".env");
+  try {
+    const content = await Bun.file(envPath).text();
+    const vars: Record<string, string> = {};
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      vars[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+    return vars;
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  console.log("");
+  console.log(bold("  Telegram Connection Test"));
+  console.log("");
+
+  const env = await loadEnv();
+  const token = env.TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_BOT_TOKEN || "";
+  const userId = env.TELEGRAM_USER_ID || process.env.TELEGRAM_USER_ID || "";
+
+  // Check token exists
+  if (!token || token === "your_bot_token_from_botfather") {
+    console.log(`  ${FAIL} TELEGRAM_BOT_TOKEN not set in .env`);
+    console.log(`      ${dim("Get one from @BotFather on Telegram")}`);
+    process.exit(1);
+  }
+  console.log(`  ${PASS} Bot token found`);
+
+  // Check user ID exists
+  if (!userId || userId === "your_telegram_user_id") {
+    console.log(`  ${FAIL} TELEGRAM_USER_ID not set in .env`);
+    console.log(`      ${dim("Get yours from @userinfobot on Telegram")}`);
+    process.exit(1);
+  }
+  console.log(`  ${PASS} User ID found: ${userId}`);
+
+  // Test bot token with getMe
+  console.log(`\n  Testing bot token...`);
+  try {
+    const meRes = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+    const meData = await meRes.json() as any;
+
+    if (!meData.ok) {
+      console.log(`  ${FAIL} Invalid bot token`);
+      console.log(`      ${dim(meData.description || "Check your token with @BotFather")}`);
+      process.exit(1);
+    }
+
+    console.log(`  ${PASS} Bot: @${meData.result.username} (${meData.result.first_name})`);
+  } catch (err: any) {
+    console.log(`  ${FAIL} Could not reach Telegram API`);
+    console.log(`      ${dim(err.message)}`);
+    process.exit(1);
+  }
+
+  // Send test message
+  console.log(`\n  Sending test message...`);
+  try {
+    const msgRes = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: userId,
+        text: "✅ Connection test successful! Your bot is working.",
+      }),
+    });
+    const msgData = await msgRes.json() as any;
+
+    if (!msgData.ok) {
+      if (msgData.description?.includes("chat not found")) {
+        console.log(`  ${FAIL} Could not reach user ${userId}`);
+        console.log(`      ${dim("Make sure you've started a conversation with your bot first.")}`);
+        console.log(`      ${dim("Open Telegram, find your bot, and send /start")}`);
+      } else {
+        console.log(`  ${FAIL} Send failed: ${msgData.description}`);
+      }
+      process.exit(1);
+    }
+
+    console.log(`  ${PASS} Test message sent! Check your Telegram.`);
+  } catch (err: any) {
+    console.log(`  ${FAIL} Could not send message`);
+    console.log(`      ${dim(err.message)}`);
+    process.exit(1);
+  }
+
+  console.log(`\n  ${green("All good!")} Your Telegram bot is configured correctly.`);
+  console.log("");
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});

--- a/setup/verify.ts
+++ b/setup/verify.ts
@@ -1,0 +1,152 @@
+/**
+ * Claude Telegram Relay — Verify Setup
+ *
+ * Runs all health checks in sequence: env, Telegram, Supabase,
+ * services, and reports overall status.
+ *
+ * Usage: bun run setup/verify.ts
+ */
+
+import { existsSync } from "fs";
+import { join, dirname } from "path";
+
+const PROJECT_ROOT = dirname(import.meta.dir);
+
+// Colors
+const green = (s: string) => `\x1b[32m${s}\x1b[0m`;
+const red = (s: string) => `\x1b[31m${s}\x1b[0m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[0m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[0m`;
+const bold = (s: string) => `\x1b[1m${s}\x1b[0m`;
+
+const PASS = green("✓");
+const FAIL = red("✗");
+const WARN = yellow("!");
+
+let passed = 0;
+let failed = 0;
+let warned = 0;
+
+function pass(msg: string) { console.log(`  ${PASS} ${msg}`); passed++; }
+function fail(msg: string) { console.log(`  ${FAIL} ${msg}`); failed++; }
+function warn(msg: string) { console.log(`  ${WARN} ${msg}`); warned++; }
+
+// Load .env
+async function loadEnv(): Promise<Record<string, string>> {
+  try {
+    const content = await Bun.file(join(PROJECT_ROOT, ".env")).text();
+    const vars: Record<string, string> = {};
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq === -1) continue;
+      vars[trimmed.slice(0, eq).trim()] = trimmed.slice(eq + 1).trim();
+    }
+    return vars;
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  console.log("");
+  console.log(bold("  Claude Telegram Relay — Health Check"));
+  console.log("");
+
+  const env = await loadEnv();
+
+  // 1. Files
+  console.log(bold("  Files"));
+  existsSync(join(PROJECT_ROOT, ".env")) ? pass(".env exists") : fail(".env missing — run: bun run setup");
+  existsSync(join(PROJECT_ROOT, "node_modules")) ? pass("Dependencies installed") : fail("node_modules missing — run: bun install");
+  existsSync(join(PROJECT_ROOT, "config", "profile.md")) ? pass("Profile configured") : warn("No profile.md — copy config/profile.example.md");
+
+  // 2. Telegram
+  console.log(`\n${bold("  Telegram")}`);
+  const token = env.TELEGRAM_BOT_TOKEN || "";
+  const userId = env.TELEGRAM_USER_ID || "";
+
+  if (!token || token.includes("your_")) {
+    fail("TELEGRAM_BOT_TOKEN not set");
+  } else {
+    try {
+      const res = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+      const data = await res.json() as any;
+      data.ok ? pass(`Bot: @${data.result.username}`) : fail(`Invalid token: ${data.description}`);
+    } catch (e: any) {
+      fail(`Telegram API unreachable: ${e.message}`);
+    }
+  }
+
+  if (!userId || userId.includes("your_")) {
+    fail("TELEGRAM_USER_ID not set");
+  } else {
+    pass(`User ID: ${userId}`);
+  }
+
+  // 3. Supabase
+  console.log(`\n${bold("  Supabase")}`);
+  const supaUrl = env.SUPABASE_URL || "";
+  const supaKey = env.SUPABASE_ANON_KEY || "";
+
+  if (!supaUrl || supaUrl.includes("your_")) {
+    warn("SUPABASE_URL not set (memory won't persist)");
+  } else if (!supaKey || supaKey.includes("your_")) {
+    warn("SUPABASE_ANON_KEY not set");
+  } else {
+    for (const table of ["messages", "memory", "logs"]) {
+      try {
+        const res = await fetch(`${supaUrl}/rest/v1/${table}?select=*&limit=1`, {
+          headers: { apikey: supaKey, Authorization: `Bearer ${supaKey}` },
+        });
+        res.status === 200 ? pass(`Table "${table}" OK`) : fail(`Table "${table}": ${res.status}`);
+      } catch (e: any) {
+        fail(`Supabase unreachable: ${e.message}`);
+        break;
+      }
+    }
+  }
+
+  // 4. Services (macOS only)
+  if (process.platform === "darwin") {
+    console.log(`\n${bold("  Services (launchd)")}`);
+    for (const label of ["com.claude.telegram-relay", "com.claude.smart-checkin", "com.claude.morning-briefing"]) {
+      const proc = Bun.spawn(["launchctl", "list", label], { stdout: "pipe", stderr: "pipe" });
+      const code = await proc.exited;
+      code === 0 ? pass(`${label} loaded`) : warn(`${label} not loaded`);
+    }
+  }
+
+  // 5. Optional
+  console.log(`\n${bold("  Optional")}`);
+  env.GEMINI_API_KEY && !env.GEMINI_API_KEY.includes("your_")
+    ? pass("Voice transcription (Gemini) configured")
+    : warn("No GEMINI_API_KEY — voice messages won't be transcribed");
+
+  env.USER_NAME && !env.USER_NAME.includes("Your ")
+    ? pass(`Name: ${env.USER_NAME}`)
+    : warn("USER_NAME not set in .env");
+
+  env.USER_TIMEZONE && env.USER_TIMEZONE !== "UTC"
+    ? pass(`Timezone: ${env.USER_TIMEZONE}`)
+    : warn("USER_TIMEZONE is UTC — update to your local timezone");
+
+  // Summary
+  console.log(`\n${bold("  Summary")}`);
+  console.log(`  ${green(`${passed} passed`)}  ${failed > 0 ? red(`${failed} failed`) : ""}  ${warned > 0 ? yellow(`${warned} warnings`) : ""}`);
+
+  if (failed === 0) {
+    console.log(`\n  ${green("Your bot is ready!")} Run: bun run start`);
+  } else {
+    console.log(`\n  ${red("Fix the failures above, then re-run:")} bun run setup:verify`);
+  }
+  console.log("");
+
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(`\n  ${red("Error:")} ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Complete free course infrastructure for the Claude Telegram Relay:

- **CLAUDE.md** — 7-phase guided setup that Claude Code reads automatically. Users clone the repo, type `claude`, and get walked through everything conversationally.
- **setup/install.ts** — Prerequisites checker (bun, claude), installs deps, creates dirs, preps .env
- **setup/test-telegram.ts** — Verifies bot token by sending a test message
- **setup/test-supabase.ts** — Verifies database connection and checks required tables
- **setup/configure-launchd.ts** — Auto-generates and loads macOS launchd plist files
- **setup/configure-services.ts** — PM2-based service setup for Windows/Linux
- **setup/verify.ts** — Full health check (env, Telegram, Supabase, services, optional features)
- **config/profile.example.md** — Personalization template loaded by relay on every message
- **db/schema.sql** — Canonical database schema location
- **README.md** — Complete rewrite with guided + manual setup paths, full command reference, project structure, and course CTA

Also updates:
- `.env.example` — Clearer structure with required/optional sections, Supabase promoted to required
- `.gitignore` — Excludes logs/, config/profile.md, config/schedule.json
- `package.json` — All setup/test/service scripts added
- `src/relay.ts` — Loads profile.md, uses USER_NAME/USER_TIMEZONE from env

## Test plan

- [ ] Clone fresh, run `bun run setup` — should install deps and create .env
- [ ] Fill .env, run `bun run test:telegram` — should send test message
- [ ] Fill Supabase keys, run `bun run test:supabase` — should verify tables
- [ ] Run `bun run start` — bot should respond on Telegram
- [ ] Run `bun run setup:launchd -- --service relay` — should load plist
- [ ] Run `bun run setup:verify` — should report all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)