### PR TITLE
Fix path traversal in document handler

### DIFF
--- a/src/relay.ts
+++ b/src/relay.ts
@@ -10,7 +10,7 @@
 import { Bot, Context } from "grammy";
 import { spawn } from "bun";
 import { writeFile, mkdir, readFile, unlink } from "fs/promises";
-import { join, dirname } from "path";
+import { join, dirname, basename } from "path";
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { transcribe } from "./transcribe.ts";
 import {
@@ -362,7 +362,7 @@ bot.on("message:document", async (ctx) => {
   try {
     const file = await ctx.getFile();
     const timestamp = Date.now();
-    const fileName = doc.file_name || `file_${timestamp}`;
+    const fileName = basename(doc.file_name || `file_${timestamp}`);
     const filePath = join(UPLOADS_DIR, `${timestamp}_${fileName}`);
 
     const response = await fetch(


### PR DESCRIPTION
## Summary

- Wrap `doc.file_name` in `path.basename()` before joining with `UPLOADS_DIR` to prevent directory traversal via crafted filenames

## Problem

In the document upload handler (`relay.ts`), the Telegram-supplied `doc.file_name` is used directly in `path.join(UPLOADS_DIR, ...)`. Since `path.join()` resolves `..` segments, a malicious filename like `../../../.bashrc` escapes the uploads directory:

```
join("/home/user/.claude-relay/uploads", "1234_../../../.bashrc")
→ "/home/.bashrc"
```

This is exploitable when `TELEGRAM_USER_ID` is not set in `.env` (the bot accepts documents from any Telegram user in that configuration).

## Fix

```typescript
// Before
const fileName = doc.file_name || `file_${timestamp}`;

// After
const fileName = basename(doc.file_name || `file_${timestamp}`);
```

`path.basename("../../../.bashrc")` → `".bashrc"` — all directory components are stripped, confining writes to `UPLOADS_DIR` regardless of the input filename.

## Test plan

- [ ] Send a document with a normal filename — verify it saves and processes correctly
- [ ] Send a document with `../` in the filename — verify the file is written inside `UPLOADS_DIR` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)